### PR TITLE
Allow more advanced search / distance function implementations

### DIFF
--- a/DBSCAN.RBush/RBushSpatialIndex.cs
+++ b/DBSCAN.RBush/RBushSpatialIndex.cs
@@ -9,7 +9,7 @@ namespace DBSCAN.RBush
 	public class RBushSpatialIndex<T> : ISpatialIndex<T>
 		where T : ISpatialData, IPointData
 	{
-		public delegate double DistanceFunction(in Point a, in Point b);
+		public delegate double DistanceFunction(in IPointData a, in IPointData b);
 
 		private RBush<T> tree;
 		private DistanceFunction distanceFunction;
@@ -29,10 +29,10 @@ namespace DBSCAN.RBush
 
 		public IReadOnlyList<T> Search() => this.tree.Search();
 
-		public static double EuclideanDistance(in Point a, in Point b)
+		public static double EuclideanDistance(in IPointData a, in IPointData b)
 		{
-			var xDist = b.X - a.X;
-			var yDist = b.Y - a.Y;
+			var xDist = b.Point.X - a.Point.X;
+			var yDist = b.Point.Y - a.Point.Y;
 			return Math.Sqrt(xDist * xDist + yDist * yDist);
 		}
 
@@ -46,7 +46,7 @@ namespace DBSCAN.RBush
 
 			var l = new List<T>();
 			foreach (var q in this.tree.Search(rectangle))
-				if (distanceFunction(p.Point, q.Point) < epsilon)
+				if (distanceFunction(p, q) < epsilon)
 					l.Add(q);
 			return l;
 		}

--- a/DBSCAN.RBush/RBushSpatialIndex.cs
+++ b/DBSCAN.RBush/RBushSpatialIndex.cs
@@ -36,17 +36,17 @@ namespace DBSCAN.RBush
 			return Math.Sqrt(xDist * xDist + yDist * yDist);
 		}
 
-		public IReadOnlyList<T> Search(in Point p, double epsilon)
+		public IReadOnlyList<T> Search(in IPointData p, double epsilon)
 		{
 			var rectangle = new Envelope(
-				minX: p.X - epsilon,
-				minY: p.Y - epsilon,
-				maxX: p.X + epsilon,
-				maxY: p.Y + epsilon);
+				minX: p.Point.X - epsilon,
+				minY: p.Point.Y - epsilon,
+				maxX: p.Point.X + epsilon,
+				maxY: p.Point.Y + epsilon);
 
 			var l = new List<T>();
 			foreach (var q in this.tree.Search(rectangle))
-				if (distanceFunction(p, q.Point) < epsilon)
+				if (distanceFunction(p.Point, q.Point) < epsilon)
 					l.Add(q);
 			return l;
 		}

--- a/DBSCAN/DBSCAN.cs
+++ b/DBSCAN/DBSCAN.cs
@@ -38,7 +38,7 @@ namespace DBSCAN
 				if (p.Visited) continue;
 
 				p.Visited = true;
-				var candidates = index.Search(p.Point, epsilon);
+				var candidates = index.Search(p, epsilon);
 
 				if (candidates.Count >= minimumPointsPerCluster)
 				{
@@ -76,7 +76,7 @@ namespace DBSCAN
 				if (!newPoint.Visited)
 				{
 					newPoint.Visited = true;
-					var newNeighbors = index.Search(newPoint.Point, epsilon);
+					var newNeighbors = index.Search(newPoint, epsilon);
 					if (newNeighbors.Count >= minimumPointsPerCluster)
 						foreach (var p in newNeighbors)
 							queue.Enqueue(p);

--- a/DBSCAN/ISpatialIndex.cs
+++ b/DBSCAN/ISpatialIndex.cs
@@ -7,6 +7,6 @@ namespace DBSCAN
 	public interface ISpatialIndex<out T>
 	{
 		IReadOnlyList<T> Search();
-		IReadOnlyList<T> Search(in Point p, double epsilon);
+		IReadOnlyList<T> Search(in IPointData p, double epsilon);
 	}
 }

--- a/DBSCAN/ListSpatialIndex.cs
+++ b/DBSCAN/ListSpatialIndex.cs
@@ -7,7 +7,7 @@ namespace DBSCAN
 {
 	public class ListSpatialIndex<T> : ISpatialIndex<T> where T : IPointData
 	{
-		public delegate double DistanceFunction(in Point a, in Point b);
+		public delegate double DistanceFunction(in IPointData a, in IPointData b);
 
 		private IReadOnlyList<T> list;
 		private DistanceFunction distanceFunction;
@@ -21,10 +21,10 @@ namespace DBSCAN
 			this.distanceFunction = distanceFunction;
 		}
 
-		public static double EuclideanDistance(in Point a, in Point b)
+		public static double EuclideanDistance(in IPointData a, in IPointData b)
 		{
-			var xDist = b.X - a.X;
-			var yDist = b.Y - a.Y;
+			var xDist = b.Point.X - a.Point.X;
+			var yDist = b.Point.Y - a.Point.Y;
 			return Math.Sqrt(xDist * xDist + yDist * yDist);
 		}
 
@@ -33,7 +33,7 @@ namespace DBSCAN
 		{
 			var l = new List<T>();
 			foreach (var q in list)
-				if (distanceFunction(p.Point, q.Point) < epsilon)
+				if (distanceFunction(p, q) < epsilon)
 					l.Add(q);
 			return l;
 		}

--- a/DBSCAN/ListSpatialIndex.cs
+++ b/DBSCAN/ListSpatialIndex.cs
@@ -29,11 +29,11 @@ namespace DBSCAN
 		}
 
 		public IReadOnlyList<T> Search() => list;
-		public IReadOnlyList<T> Search(in Point p, double epsilon)
+		public IReadOnlyList<T> Search(in IPointData p, double epsilon)
 		{
 			var l = new List<T>();
 			foreach (var q in list)
-				if (distanceFunction(p, q.Point) < epsilon)
+				if (distanceFunction(p.Point, q.Point) < epsilon)
 					l.Add(q);
 			return l;
 		}


### PR DESCRIPTION
Hi,

I extended your implementation a little so you can access the `Item` property of a PointInfo object within custom `Search` or `DistanceFunction` implementations. I used this to put the calculated distance at `double.PositiveInfinity` if certain evaluations match to exclude objects from being clustered.

Example:
If you have mixed points in your set with different colors and you only want to build clusters with points from all the same color. If the color of `a` and `b` within the distance function are not equal I set the distance to infinity, this allows to build only clusters from the same colors (assuming you don't set epsilon to Infinity 😉 ).

Maybe you or some one else might find this helpful too, feel free to merge this.

best regards and thanks a lot for you prior work!